### PR TITLE
get_frame_2D fix

### DIFF
--- a/nd2reader/parser.py
+++ b/nd2reader/parser.py
@@ -77,7 +77,7 @@ class Parser(object):
         else:
             return image
 
-    def get_image_by_attributes(self, frame_number, field_of_view, channel_name, z_level, height, width):
+    def get_image_by_attributes(self, frame_number, field_of_view, channel, z_level, height, width):
         """Gets an image based on its attributes alone
 
         Args:
@@ -94,7 +94,7 @@ class Parser(object):
         """
         image_group_number = self._calculate_image_group_number(frame_number, field_of_view, z_level)
         try:
-            timestamp, raw_image_data = self._get_raw_image_data(image_group_number, self._channel_offset[channel_name],
+            timestamp, raw_image_data = self._get_raw_image_data(image_group_number, channel,
                                                                  height, width)
         except (TypeError, NoImageError):
             return Frame([], frame_no=frame_number, metadata=self._get_frame_metadata())

--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -67,14 +67,9 @@ class ND2Reader(FramesSequenceND):
             numpy.ndarray: The requested frame
 
         """
-        try:
-            c_name = self.metadata["channels"][c]
-        except KeyError:
-            c_name = self.metadata["channels"][0]
-
         x = self.metadata["width"] if x <= 0 else x
         y = self.metadata["height"] if y <= 0 else y
-        return self._parser.get_image_by_attributes(t, v, c_name, z, y, x)
+        return self._parser.get_image_by_attributes(t, v, c, z, y, x)
 
     @property
     def parser(self):


### PR DESCRIPTION
Sorry it took me so long when the changes are so simple. This is my first pull request so I wanted to make sure I was doing things right and so just kept putting off educating myself. I ran the tests in test.py and all were ok. All I know for sure that I have changed is get_frame_2d and the function from parser.py that it calls. This is the fix that makes the library function with my ND2 files. I'm not sure if other functions follow the same channel handling and might need to be fixed in the same way, but at least my change passed the tests.