### PR TITLE
include only valid loops in experiment metadata

### DIFF
--- a/nd2reader/common_raw_metadata.py
+++ b/nd2reader/common_raw_metadata.py
@@ -48,6 +48,11 @@ def get_loops_from_data(loop_data):
 
         # take the first dictionary element, it contains all loop data
         loops = loop_data[six.b('pPeriod')][list(loop_data[six.b('pPeriod')].keys())[0]]
+
+        # exclude invalid periods
+        if six.b('pPeriodValid') in loop_data:
+            loops = [loops[i] for i in range(len(loops)) if loop_data[six.b('pPeriodValid')][i] == 1]
+
     return loops
 
 


### PR DESCRIPTION
Hi Ruben, 

thanks for your work on the nd2reader package!

In the data from our experiments, the metadata contains a variety of "loops" that are not actually included in the file. The `pPeriodValid` key of of `uLoopPars` apparently marks those loops that are valid, i.e. included in the data file. I have therefore modified the `get_loops_from_data()` function to exclude invalid loops, which works fine for our experimental data - however I could only validate it on our data and I'm not sure whether it will be the correct approach for any ND2 file. Anyway, I hope this will be of help for you.

Gregor