### PR TITLE
Image events

### DIFF
--- a/nd2reader/label_map.py
+++ b/nd2reader/label_map.py
@@ -44,6 +44,16 @@ class LabelMap(object):
         return self._get_location(six.b("ImageMetadataLV!"))
 
     @property
+    def image_events(self):
+        """Get the location of the image events
+
+        Returns:
+            int: The location of the image events
+
+        """
+        return self._get_location(six.b("ImageEventsLV!"))
+
+    @property
     def image_metadata_sequence(self):
         """Get the location of the image metadata sequence. There is always only one of these, even though it has a pipe
          followed by a zero, which is how they do indexes.

--- a/nd2reader/raw_metadata.py
+++ b/nd2reader/raw_metadata.py
@@ -393,9 +393,12 @@ class RawMetadata(object):
         if events is None or six.b('RLxExperimentRecord') not in events:
             return
 
-        events = events[six.b('RLxExperimentRecord')][six.b('pEvents')][six.b('')]
+        events = events[six.b('RLxExperimentRecord')][six.b('pEvents')]
 
-        for event in events:
+        if len(events) == 0:
+            return
+
+        for event in events[six.b('')]:
             event_info = {
                 'index': event[six.b('I')],
                 'time': event[six.b('T')],
@@ -405,7 +408,6 @@ class RawMetadata(object):
                 event_info['name'] = event_names[event_info['type']]
 
             self._metadata_parsed['events'].append(event_info)
-
 
     @property
     def image_text_info(self):

--- a/nd2reader/raw_metadata.py
+++ b/nd2reader/raw_metadata.py
@@ -379,11 +379,31 @@ class RawMetadata(object):
 
         """
 
+        # list of event names manually extracted from an ND2 file that contains all manually
+        # insertable events from NIS-Elements software (4.60.00 (Build 1171) Patch 02)
         event_names = {
+            1: 'Autofocus',
+            7: 'Command Executed',
+            9: 'Experiment Paused',
             10: 'Experiment Resumed',
+            11: 'Experiment Stopped by User',
+            13: 'Next Phase Moved by User',
             14: 'Experiment Paused for Refocusing',
+            16: 'External Stimulation',
+            33: 'User 1',
+            34: 'User 2',
+            35: 'User 3',
+            36: 'User 4',
+            37: 'User 5',
+            38: 'User 6',
+            39: 'User 7',
+            40: 'User 8',
             44: 'No Acquisition Phase Start',
-            45: 'No Acquisition Phase End'
+            45: 'No Acquisition Phase End',
+            46: 'Hardware Error',
+            47: 'N-STORM',
+            48: 'Incubation Info',
+            49: 'Incubation Error'
         }
 
         self._metadata_parsed['events'] = []

--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -103,6 +103,16 @@ class ND2Reader(FramesSequenceND):
         return self._timesteps
 
     @property
+    def events(self):
+        """Get the events of the experiment
+
+        Returns:
+            iterator of events as dict
+        """
+
+        return self._get_metadata_property("events")
+
+    @property
     def frame_rate(self):
         """The (average) frame rate
         
@@ -186,3 +196,5 @@ class ND2Reader(FramesSequenceND):
         self._timesteps = np.array(list(self._parser._raw_metadata.acquisition_times), dtype=np.float) * 1000.0
 
         return self._timesteps
+
+


### PR DESCRIPTION
Hi Ruben,

I have added the possibility of accessing the event data in nd2 files. Unfortunately, the actual names of the events seem not to be included in the nd2 files, but instead only an numeric identifier. I have therefore added all possible event types to an nd2 file to be able to map the identifiers to the actual name and have hard-coded this map in a `_parse_events()` function in `raw_metadata.py`.

As I have only access to NIS-Elements software version 4.60.00 (Build 1171) Patch 02, I don't know whether my code works in all cases. I hope it will be useful for you nevertheless.

Gregor