### PR TITLE
Fix to allow reading of ND2-files with missing frames.

### DIFF
--- a/nd2reader/exceptions.py
+++ b/nd2reader/exceptions.py
@@ -6,17 +6,6 @@ class InvalidVersionError(Exception):
     """
     pass
 
-
-class NoImageError(Exception):
-    """No image found.
-
-    Some apparent images in ND2s are just completely blank placeholders. These are used when the number of images per
-    cycle are unequal (e.g. if you take fluorescent images every 2 minutes, and bright field images every minute).
-
-    """
-    pass
-
-
 class EmptyFileError(Exception):
     """This .nd2 file seems to be empty.
 

--- a/nd2reader/parser.py
+++ b/nd2reader/parser.py
@@ -3,6 +3,7 @@ import struct
 
 import array
 import six
+import warnings
 from pims.base_frames import Frame
 import numpy as np
 
@@ -72,7 +73,7 @@ class Parser(object):
         try:
             timestamp, image = self._get_raw_image_data(image_group_number, channel_offset, self.metadata["height"],
                                                         self.metadata["width"])
-        except (TypeError, NoImageError):
+        except (TypeError):
             return Frame([], frame_no=frame_number, metadata=self._get_frame_metadata())
         else:
             return image
@@ -101,7 +102,7 @@ class Parser(object):
         try:
             timestamp, raw_image_data = self._get_raw_image_data(image_group_number, channel,
                                                                  height, width)
-        except (TypeError, NoImageError):
+        except (TypeError):
             return Frame([], frame_no=frame_number, metadata=self._get_frame_metadata())
         else:
             return raw_image_data
@@ -283,11 +284,12 @@ class Parser(object):
         if np.any(image_data):
             return timestamp, Frame(image_data, metadata=self._get_frame_metadata())
 
-        # If a blank "gap" image is encountered, generate an empty frame (black image) of corresponding height and width to avoid 
-        # errors with ND2-files with missing frames.
-        else: 
-            empty_frame = np.zeros([height, width])
-            return timestamp, Frame(empty_frame, metadata=self._get_frame_metadata())     
+        # If a blank "gap" image is encountered, generate an array of corresponding height and width to avoid 
+        # errors with ND2-files with missing frames. Array is filled with nan to reflect that data is missing. 
+        else:
+            empty_frame = np.full((height, width), np.nan)
+            warnings.warn('ND2 file contains gap frames which are represented by np.nan-filled arrays')
+            return timestamp, Frame(empty_frame, metadata=self._get_frame_metadata())  
 
     def _get_frame_metadata(self):
         """Get the metadata for one frame

--- a/nd2reader/parser.py
+++ b/nd2reader/parser.py
@@ -7,7 +7,7 @@ from pims.base_frames import Frame
 import numpy as np
 
 from nd2reader.common import get_version, read_chunk
-from nd2reader.exceptions import InvalidVersionError, NoImageError
+from nd2reader.exceptions import InvalidVersionError
 from nd2reader.label_map import LabelMap
 from nd2reader.raw_metadata import RawMetadata
 
@@ -288,8 +288,6 @@ class Parser(object):
         else: 
             empty_frame = np.zeros([height, width])
             return timestamp, Frame(empty_frame, metadata=self._get_frame_metadata())     
-
-        # raise NoImageError # <-- delete?
 
     def _get_frame_metadata(self):
         """Get the metadata for one frame

--- a/nd2reader/parser.py
+++ b/nd2reader/parser.py
@@ -288,7 +288,7 @@ class Parser(object):
         # errors with ND2-files with missing frames. Array is filled with nan to reflect that data is missing. 
         else:
             empty_frame = np.full((height, width), np.nan)
-            warnings.warn('ND2 file contains gap frames which are represented by np.nan-filled arrays')
+            warnings.warn('ND2 file contains gap frames which are represented by np.nan-filled arrays; to convert to zeros use e.g. np.nan_to_num(array)')
             return timestamp, Frame(empty_frame, metadata=self._get_frame_metadata())  
 
     def _get_frame_metadata(self):

--- a/nd2reader/parser.py
+++ b/nd2reader/parser.py
@@ -283,7 +283,13 @@ class Parser(object):
         if np.any(image_data):
             return timestamp, Frame(image_data, metadata=self._get_frame_metadata())
 
-        raise NoImageError
+        # If a blank "gap" image is encountered, generate an empty frame (black image) of corresponding height and width to avoid 
+        # errors with ND2-files with missing frames.
+        else: 
+            empty_frame = np.zeros([height, width])
+            return timestamp, Frame(empty_frame, metadata=self._get_frame_metadata())     
+
+        # raise NoImageError # <-- delete?
 
     def _get_frame_metadata(self):
         """Get the metadata for one frame


### PR DESCRIPTION
**Summary:**
A simple fix to prevent errors when reading ND2-files with missing frames. 

**Problem addressed:**
Elements allows the acquisition of multidimensional images in which not all frames are collected in all dimensions. E.g. for an image-stack with channels 405, 488 and DIC, 7 z-planes and time-points, one may select to only acquire a single z-plane for the DIC channel (the "home position"), or to skip time-points for some other channel. This leads to empty frames in the ND2-file. This issue is known and is currently handled within `_get_raw_image_data`:

https://github.com/rbnvrw/nd2reader/blob/1d43617c55c7ea90b82596b4b03d9029c8258af4/nd2reader/parser.py#L279-L286

For now, if an empty frame is encountered, a custom `NoImageError `exception is raised, which simply calls `pass`:

https://github.com/rbnvrw/nd2reader/blob/1d43617c55c7ea90b82596b4b03d9029c8258af4/nd2reader/exceptions.py#L10-L17

This currently can lead to fatal errors. E.g. for a multipoint ND2 file, which has v,c,z,y,x dimensions, but is missing z-frames in one channel:

```
# without fix: 

with ND2Reader(path + '2019-8-14_24W-S3a-Sec1-A1_012.nd2') as images:
    images.bundle_axes = 'zcyx'
    images.iter_axes = 'v'
    print(f"Fields-of-view in ND2 file: {len(images)}")
    
    im = images[0]
    images.close()
    
print(f"Shape of single field-of-view: {im.shape}")
```
results in:

```
Fields-of-view in ND2 file: 11
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-87247cc40ee5> in <module>
      6     print(f"Fields-of-view in ND2 file: {len(images)}")
      7 
----> 8     im = images[0]
      9     images.close()
     10 

C:\Anaconda3\envs\ND2tiff_dev\lib\site-packages\slicerator\__init__.py in __getitem__(self, i)
    186                 indices, new_length = key_to_indices(i, len(self))
    187                 if new_length is None:
--> 188                     return self._get(indices)
    189                 else:
    190                     return cls(self, indices, new_length, propagate_attrs)

C:\Anaconda3\envs\ND2tiff_dev\lib\site-packages\pims\base_frames.py in __getitem__(self, key)
    146         """__getitem__ is handled by Slicerator. In all pims readers, the data
    147         returning function is get_frame."""
--> 148         return self.get_frame(key)
    149 
    150     def __iter__(self):

C:\Anaconda3\envs\ND2tiff_dev\lib\site-packages\pims\base_frames.py in get_frame(self, i)
    640         coords.update(**{k: v for k, v in zip(self.iter_axes, iter_coords)})
    641 
--> 642         result = self._get_frame_wrapped(**coords)
    643         if hasattr(result, 'metadata'):
    644             metadata = result.metadata
	
C:\Anaconda3\envs\ND2tiff_dev\lib\site-packages\pims\base_frames.py in get_frame_bundled(**ind)
    314             ind.update({n: i for n, i in zip(to_iter, indices)})
    315             frame = get_frame(**ind)
--> 316             result[indices] = frame
    317 
    318             if hasattr(frame, 'metadata'):

ValueError: could not broadcast input array from shape (0) into shape (1806,1278)
```

**Reproduce:**

File to reproduce this error can be found here: 
https://nd2tiff.s3-us-west-2.amazonaws.com/2019-9-5_11-Multi-point-test-image_001.zip

To reproduce, install the current pip version with: `pip install nd2reader`.* Then run the code above with adjusted path variable. 

***_NOTE_**: commit 1d43617 (Use _register_get_frame functions) is ahead of the pip and anaconda versions. It changes the way axes are generated and seems to break functionality of the code posted above... sorry if I'm missing something obvious. For now one has to use the current pip or anaconda versions. Alternatively, to reproduce/test using the repo, use the previous commit 14f8d70 and adjust imports accordingly. PR is nevertheless based on most recent commit, so nothing will be reverted. 

**Fix:**
To avoid the broadcasting error, empty frames should be replaced with black images of corresponding height and width. I implemented this directly in `_get_raw_image_data` since moving it inside the `NoImageError` exception seems like more hustle... Then: 

```
# with fix: 

with ND2Reader(path + '2019-8-14_24W-S3a-Sec1-A1_012.nd2') as images:
    images.bundle_axes = 'zcyx'
    images.iter_axes = 'v'
    print(f"Fields-of-view in ND2 file: {len(images)}")
    
    im = images[0]
    images.close()
    
print(f"Shape of single field-of-view: {im.shape}")
```

correctly yields: 

```
Fields-of-view in ND2 file: 11
Shape of single field-of-view: (7, 5, 1806, 1278)
```




