### PR TITLE
add a check that filename passed to ND2Reader has extension .nd2 

### DIFF
--- a/nd2reader/exceptions.py
+++ b/nd2reader/exceptions.py
@@ -1,3 +1,11 @@
+class InvalidFileType(Exception):
+    """Non .nd2 extension file.
+
+    File does not have an extension .nd2.
+
+    """
+    pass
+
 class InvalidVersionError(Exception):
     """Unknown version.
 

--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -1,7 +1,7 @@
 from pims import Frame
 from pims.base_frames import FramesSequenceND
 
-from nd2reader.exceptions import EmptyFileError
+from nd2reader.exceptions import EmptyFileError, InvalidFileType
 from nd2reader.parser import Parser
 import numpy as np
 
@@ -15,6 +15,10 @@ class ND2Reader(FramesSequenceND):
 
     def __init__(self, filename):
         super(ND2Reader, self).__init__()
+
+        if not filename.endswith(".nd2"):
+            raise InvalidFileType(f"The file {filename} you want to read with nd2reader does not have extension .nd2.")
+
         self.filename = filename
 
         # first use the parser to parse the file

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -4,12 +4,15 @@ import struct
 
 from pims import Frame
 from nd2reader.artificial import ArtificialND2
-from nd2reader.exceptions import EmptyFileError
+from nd2reader.exceptions import EmptyFileError, InvalidFileType
 from nd2reader.reader import ND2Reader
 from nd2reader.parser import Parser
 
 
 class TestReader(unittest.TestCase):
+    def test_invalid_file_extension(self):
+        self.assertRaises(InvalidFileType, lambda: ND2Reader('test_data/invalid_extension_file.inv'))
+
     def test_extension(self):
         self.assertTrue('nd2' in ND2Reader.class_exts())
 


### PR DESCRIPTION
- The current implementation of ND2Reader constructor raises `InvalidVersionError` if the passed file does not have extension `.nd2`, which is misleading. Hence, I decided to add a check to the constructor to make sure that the passed file has correct nd2 extension.

- Add an exception InvalidFileType

- Add a test for the new behavior of ND2Reader constructor. I saw `test_extension`, which might have the same functionality, which I implemented, but in the current constructor the parser, which raises the `InvalidVersionError`, is called before any other check.

Thanks!