### PR TITLE
Removed self.__class__ from super() call

### DIFF
--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -14,7 +14,7 @@ class ND2Reader(FramesSequenceND):
     class_priority = 12
 
     def __init__(self, filename):
-        super(self.__class__, self).__init__()
+        super(ND2Reader, self).__init__()
         self.filename = filename
 
         # first use the parser to parse the file


### PR DESCRIPTION
This is relatively urgent for me as I would like to be able to extend the ND2Reader (i.e., use it as a Base Class in a custom class of mine, in Python3) :)

When using `self.__class__` in the `super()` call, Python3 complains about argument passing from the Child Class. I think this is a bad practice (see [link](https://stackoverflow.com/a/19776143/1593536)), so I replaced it with the explicit Class name!

I hope this is acceptable and can be of help to others too!