### PR TITLE
Update to reader.py for issue #35

### DIFF
--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -11,6 +11,7 @@ class ND2Reader(FramesSequenceND):
     This is the main class: use this to process your .nd2 files.
     """
 
+    _fh = None
     class_priority = 12
 
     def __init__(self, fh):
@@ -27,26 +28,24 @@ class ND2Reader(FramesSequenceND):
                     ("The file %s you want to read with nd2reader" % fh)
                     + " does not have extension .nd2."
                 )
+            fh = open(fh, "rb")
 
-            self = ND2Reader(open(fh, "rb"))
-            self.filename = fh
-        else:
-            self._fh = fh
-            self.filename = ""
+        self._fh = fh
+        self.filename = ""
 
-            self._parser = Parser(self._fh)
+        self._parser = Parser(self._fh)
 
-            # Setup metadata
-            self.metadata = self._parser.metadata
+        # Setup metadata
+        self.metadata = self._parser.metadata
 
-            # Set data type
-            self._dtype = self._parser.get_dtype_from_metadata()
+        # Set data type
+        self._dtype = self._parser.get_dtype_from_metadata()
 
-            # Setup the axes
-            self._setup_axes()
+        # Setup the axes
+        self._setup_axes()
 
-            # Other properties
-            self._timesteps = None
+        # Other properties
+        self._timesteps = None
 
     @classmethod
     def class_exts(cls):

--- a/nd2reader/reader.py
+++ b/nd2reader/reader.py
@@ -13,16 +13,12 @@ class ND2Reader(FramesSequenceND):
 
     class_priority = 12
 
-    def __init__(self, filename):
+    def __init__(self, fh):
         super(ND2Reader, self).__init__()
 
-        if not filename.endswith(".nd2"):
-            raise InvalidFileType("The file %s you want to read with nd2reader does not have extension .nd2." % filename)
+        self._fh = fh
+        self.filename = ""
 
-        self.filename = filename
-
-        # first use the parser to parse the file
-        self._fh = open(filename, "rb")
         self._parser = Parser(self._fh)
 
         # Setup metadata
@@ -37,6 +33,16 @@ class ND2Reader(FramesSequenceND):
         # Other properties
         self._timesteps = None
 
+    @staticmethod
+    def from_file(filename):
+        if not filename.endswith(".nd2"):
+            raise InvalidFileType("The file %s you want to read with nd2reader does not have extension .nd2." % filename)
+
+        nd2r = ND2Reader(open(filename, "rb"))
+        nd2r.filename = filename
+
+        return nd2r
+        
     @classmethod
     def class_exts(cls):
         """Let PIMS open function use this reader for opening .nd2 files

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -16,18 +16,27 @@ class TestReader(unittest.TestCase):
     def test_extension(self):
         self.assertTrue('nd2' in ND2Reader.class_exts())
 
+    def cmp_two_readers(self, r1, r2):
+        attributes = r1.data['image_attributes']['SLxImageAttributes']
+        self.assertEqual(r2.metadata['width'], attributes['uiWidth'])
+        self.assertEqual(r2.metadata['height'], attributes['uiHeight'])
+
+        self.assertEqual(r2.metadata['width'], r2.sizes['x'])
+        self.assertEqual(r2.metadata['height'], r2.sizes['y'])
+
+        self.assertEqual(r2.pixel_type, np.float64)
+        self.assertEqual(r2.iter_axes, ['t'])
+
     def test_init_and_init_axes(self):
         with ArtificialND2('test_data/test_nd2_reader.nd2') as artificial:
             with ND2Reader('test_data/test_nd2_reader.nd2') as reader:
-                attributes = artificial.data['image_attributes']['SLxImageAttributes']
-                self.assertEqual(reader.metadata['width'], attributes['uiWidth'])
-                self.assertEqual(reader.metadata['height'], attributes['uiHeight'])
+                self.cmp_two_readers(artificial, reader)
 
-                self.assertEqual(reader.metadata['width'], reader.sizes['x'])
-                self.assertEqual(reader.metadata['height'], reader.sizes['y'])
-
-                self.assertEqual(reader.pixel_type, np.float64)
-                self.assertEqual(reader.iter_axes, ['t'])
+    def test_init_from_handler(self):
+        with ArtificialND2('test_data/test_nd2_reader.nd2') as artificial:
+            with open('test_data/test_nd2_reader.nd2', "rb") as FH:
+                with ND2Reader(FH) as reader:
+                    self.cmp_two_readers(artificial, reader)
 
     def test_init_empty_file(self):
         with ArtificialND2('test_data/empty.nd2', skip_blocks=['label_map_marker']):


### PR DESCRIPTION
Proposed change according to issue #35 . Basically, the default `init` method of `ND2Reader` would now require a file handler (`io.*`) and there is a staticmethod (`from_file`) that reproduces the original behavior. What do you think? Is this an acceptable approach? Any alternative approaches? 

Also, I am not sure but at a first glance it looks like the `filename` attribute of `ND2Reader` is never used anywhere else. If it is, I'd need to fix it. Please, let me know :smile: 