### PR TITLE
Fix issue with invalid escape sequence  '\|'.

### DIFF
--- a/nd2reader/label_map.py
+++ b/nd2reader/label_map.py
@@ -72,7 +72,7 @@ class LabelMap(object):
 
         """
         if not self._image_data:
-            regex = re.compile(six.b("""ImageDataSeq\|(\d+)!"""))
+            regex = re.compile(six.b(r"ImageDataSeq\|(\d+)!"))
             for match in regex.finditer(self._data):
                 if match:
                     location = self._parse_data_location(match.end())


### PR DESCRIPTION
When importing `nd2eader` (with Python 3.12), the following warning is shown:

```
nd2reader/label_map.py:75: SyntaxWarning: invalid escape sequence '\|'
  regex = re.compile(six.b("""ImageDataSeq\|(\d+)!"""))
```

Switching to a raw string fixes the issue:

```
regex = re.compile(six.b(r"ImageDataSeq\|(\d+)!"))
```